### PR TITLE
suggest simlink for nonstandard Skim.app location

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -71,11 +71,11 @@ If you don't want to install the entire MacTeX distro, which is pretty big, Basi
 To configure inverse search, open the Preferences dialog of the Skim app, select the Sync tab, then:
 
 * uncheck the "Check for file changes" option
-* choose the Sublime Text 2 or Sublme Text 3 preset (yes, Skim now supports both ST2 and ST3 by default!)
+* choose the Sublime Text 2 or Sublme Text 3 preset (yes,  now supports both ST2 and ST3 by default!)
 
 In case you are using an old version of Skim, you can always choose the Custom preset and enter `/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl` (for ST3) in the Command field, and `"%file":%line` in the Arguments field. (This is correct as of 7/18/2013; you may want to double-check that ST3 is indeed in `/Applications/Sublime Text`; just go to the Applications folder in the Finder. Adapt as needed for ST2).
 
-If you have installed Skim in a non-standard location, there is not much you can do short of hacking the `jumpToPDF.py` file (**not supported!**). This will change in the near future. 
+If you have installed Skim in a non-standard location, there is not much you can do short of hacking the `jumpToPDF.py` file (**not supported!**), or adding a simlink to your location from the Applications directory: `ln -s /path/to/your/Skim.app /Applications/Skim.app`. This will change in the near future. 
 
 Finally, edit the file `LaTeXTools.sublime-settings` in the `User` directory to make sure that the configuration reflects your preferred TeX distribution. Open the file and scroll down to the  section titled "Platform settings." Look at the block for your OS, namely `"osx"`. Within that block, verify that the `"texpath"` setting is correct. Note that `"texpath"` **must** include `$PATH` somewhere.
 


### PR DESCRIPTION
A simple and painless solution for nonstandard Skim.app locations (e.g. installing via Homebrew Cask) is to just create a simlink in `/Applications/`.
